### PR TITLE
Fix: error handling and account validation for post operations

### DIFF
--- a/late/resources/posts.ts
+++ b/late/resources/posts.ts
@@ -1,5 +1,5 @@
 import type { LateResourceModule } from "../types";
-import { postsCreatePreSend, postsUpdatePreSend } from "../utils/routingHooks";
+import { postsCreatePreSend, postsUpdatePreSend, handleApiErrorResponse } from "../utils/routingHooks";
 import {
   buildPlatformSelector,
   buildAccountSelectors,
@@ -46,9 +46,14 @@ export const postsResource: LateResourceModule = {
         request: {
           method: "POST",
           url: "/posts",
+          ignoreHttpStatusErrors: true,
+          returnFullResponse: true,
         },
         send: {
           preSend: [postsCreatePreSend],
+        },
+        output: {
+          postReceive: [handleApiErrorResponse],
         },
       },
     },
@@ -60,9 +65,14 @@ export const postsResource: LateResourceModule = {
         request: {
           method: "PUT",
           url: "=/posts/{{ $parameter.postId }}",
+          ignoreHttpStatusErrors: true,
+          returnFullResponse: true,
         },
         send: {
           preSend: [postsUpdatePreSend],
+        },
+        output: {
+          postReceive: [handleApiErrorResponse],
         },
       },
     },
@@ -74,6 +84,11 @@ export const postsResource: LateResourceModule = {
         request: {
           method: "DELETE",
           url: "=/posts/{{ $parameter.postId }}",
+          ignoreHttpStatusErrors: true,
+          returnFullResponse: true,
+        },
+        output: {
+          postReceive: [handleApiErrorResponse],
         },
       },
     },
@@ -85,6 +100,11 @@ export const postsResource: LateResourceModule = {
         request: {
           method: "POST",
           url: "=/posts/{{ $parameter.postId }}/retry",
+          ignoreHttpStatusErrors: true,
+          returnFullResponse: true,
+        },
+        output: {
+          postReceive: [handleApiErrorResponse],
         },
       },
     },
@@ -107,6 +127,8 @@ export const postsResource: LateResourceModule = {
         request: {
           method: "POST",
           url: "/posts/bulk-upload",
+          ignoreHttpStatusErrors: true,
+          returnFullResponse: true,
           headers: {
             "Content-Type": "multipart/form-data",
           },
@@ -116,6 +138,9 @@ export const postsResource: LateResourceModule = {
           body: {
             file: "={{ { value: $parameter.csvFile, options: { filename: 'bulk-upload.csv', contentType: 'text/csv' } } }}",
           },
+        },
+        output: {
+          postReceive: [handleApiErrorResponse],
         },
       },
     },

--- a/late/utils/platformHelpers.ts
+++ b/late/utils/platformHelpers.ts
@@ -83,7 +83,7 @@ export async function loadPlatformAccounts(
     );
 
     if (!response?.accounts) {
-      return [{ name: `No ${platform} accounts found`, value: "none" }];
+      return [{ name: `No ${platform} accounts found - connect at getlate.dev first`, value: "none" }];
     }
 
     const platformAccounts = response.accounts.filter(
@@ -91,7 +91,7 @@ export async function loadPlatformAccounts(
     );
 
     if (platformAccounts.length === 0) {
-      return [{ name: `No ${platform} accounts connected`, value: "none" }];
+      return [{ name: `No ${platform} accounts connected - connect at getlate.dev first`, value: "none" }];
     }
 
     const platformConfig = SUPPORTED_PLATFORMS.find(
@@ -108,7 +108,7 @@ export async function loadPlatformAccounts(
       (error as any)?.cause?.code === "ECONNREFUSED"
         ? "Cannot connect to LATE API. Please check your internet connection."
         : (error as Error).message || "Failed to load accounts";
-    return [{ name: `Error: ${errorMsg}`, value: "error" }];
+    return [{ name: `Connection error: ${errorMsg} - check API key`, value: "error" }];
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes the issue where users see a generic "403" error when using `publishNow` instead of the actual API error message. Reported by customer Ryan Turner.

**Root cause:** The n8n node had three problems working together:
1. API error responses (with descriptive messages like "One or more accounts do not belong to this user") were being swallowed by n8n's default error handling, showing only "403"
2. When account dropdowns failed to load, placeholder values like `"none"` and `"error"` were being sent as accountIds to the API
3. No client-side validation before sending requests — empty platform arrays were sent with `publishNow: true`

## Changes

### Fix 1 — Surface API error messages (High priority)
- Added `ignoreHttpStatusErrors: true` and `returnFullResponse: true` to Create, Update, Delete, Retry, and Bulk Upload operations so n8n passes the full response to our handler instead of throwing a generic error
- Created `handleApiErrorResponse` postReceive hook that parses the API response body and throws a descriptive error: `"LATE API Error (403): One or more accounts do not belong to this user"`

### Fix 2 — Filter invalid account IDs (High priority)
- Added `.filter()` in `buildPlatformsArray()` to reject `"none"`, `"error"`, and non-24-character IDs before they reach the API

### Fix 3 — Pre-send validation (Medium priority)
- Added validation in `postsCreatePreSend()`: if no valid accounts remain after filtering and the post is not a draft, throw a clear error guiding the user to connect accounts at getlate.dev

### Fix 4 — Improve dropdown fallback messages (Low priority)
- Changed dropdown messages from `"No X accounts found"` to `"No X accounts found - connect at getlate.dev first"`
- Changed error messages from `"Error: ..."` to `"Connection error: ... - check API key"`

## Files changed

- `late/resources/posts.ts` — routing config for 5 write operations
- `late/utils/routingHooks.ts` — error handler, account filter, pre-send validation
- `late/utils/platformHelpers.ts` — dropdown fallback messages

## Test plan

- [ ] Create post with `publishNow: true` without accounts selected → descriptive error (Fix 3)
- [ ] Open node with disconnected accounts → dropdown shows improved message (Fix 4)
- [ ] Create post with invalid accountId → shows full API error message (Fix 1)
- [ ] Create post with valid accounts and `publishNow: true` → works normally
- [ ] Create draft without accounts → works (validation skipped)
- [ ] Update, Delete, Retry operations with invalid data → show API error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)