### PR TITLE
feat(tiktok): expose PHOTO carousel, auto_add_music, AIGC and commercial content settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.6.0] - 2026-05-12
+
+### Changes
+- feat(tiktok): expose PHOTO carousel media type with auto_add_music for background music
+- feat(tiktok): expose commercial content disclosure (brand organic / branded content)
+- feat(tiktok): expose AI-generated content (AIGC) flag for videos
+- feat(tiktok): expose video cover timestamp (ms) field
+
 ## [0.5.4] - 2026-04-08
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -276,8 +276,10 @@ Post to Instagram Stories:
 }
 ```
 
-#### TikTok Privacy Settings
-Control TikTok post privacy:
+#### TikTok Privacy, Photo Carousel and Disclosure Settings
+
+Control TikTok privacy plus optional PHOTO carousel media type (with background
+music), commercial content disclosure, and AIGC labeling:
 
 ```json
 {
@@ -290,13 +292,22 @@ Control TikTok post privacy:
           "privacy_level": "PUBLIC_TO_EVERYONE",
           "allow_comment": true,
           "allow_duet": true,
-          "allow_stitch": true
+          "allow_stitch": true,
+          "media_type": "PHOTO",
+          "auto_add_music": true,
+          "commercial_content_type": "brand_organic",
+          "is_brand_organic_post": true,
+          "video_made_with_ai": false
         }
       }
     }
   ]
 }
 ```
+
+PHOTO carousel posts require `media_type: "PHOTO"` and support `auto_add_music`
+to attach TikTok-recommended background music. Brand and AIGC disclosures are
+optional but required by TikTok policy when applicable.
 
 #### YouTube Settings
 Add custom thumbnails and first comments:

--- a/late/resources/posts.ts
+++ b/late/resources/posts.ts
@@ -515,6 +515,144 @@ export const postsResource: LateResourceModule = {
       description: "Allow other users to stitch this video",
     },
 
+    // TikTok PHOTO carousel + advanced disclosure fields.
+    // The API (tiktok-settings-normalizer.ts) accepts these as-is in tiktokSettings.
+    // media_type gates which downstream post_info fields TikTok consumes:
+    //   PHOTO -> auto_add_music, description, brand_*_toggle
+    //   VIDEO -> video_cover_timestamp_ms, video_made_with_ai (is_aigc)
+    // See libs/platforms/tiktok.ts:1122-1166 for the per-media-type field consumption.
+    {
+      displayName: "TikTok Media Type",
+      name: "tiktokMediaType",
+      type: "options",
+      options: [
+        { name: "Video", value: "VIDEO" },
+        { name: "Photo Carousel", value: "PHOTO" },
+      ],
+      default: "VIDEO",
+      displayOptions: {
+        show: {
+          resource: ["posts"],
+          operation: ["create", "update"],
+          selectedPlatforms: ["tiktok"],
+        },
+      },
+      description: "TikTok media type. PHOTO enables photo carousel posts with optional background music.",
+    },
+    {
+      displayName: "TikTok Photo Description",
+      name: "tiktokDescription",
+      type: "string",
+      default: "",
+      typeOptions: { rows: 3 },
+      displayOptions: {
+        show: {
+          resource: ["posts"],
+          operation: ["create", "update"],
+          selectedPlatforms: ["tiktok"],
+          tiktokMediaType: ["PHOTO"],
+        },
+      },
+      description: "Caption for the TikTok photo carousel. If empty, the post content is used.",
+    },
+    // auto_add_music is REQUIRED for TikTok photo carousels to play background music.
+    // TikTok's API defaults it to false; we must explicitly opt in.
+    {
+      displayName: "TikTok Auto Add Music",
+      name: "tiktokAutoAddMusic",
+      type: "boolean",
+      default: false,
+      displayOptions: {
+        show: {
+          resource: ["posts"],
+          operation: ["create", "update"],
+          selectedPlatforms: ["tiktok"],
+          tiktokMediaType: ["PHOTO"],
+        },
+      },
+      description: "Auto-add TikTok recommended background music to the photo carousel",
+    },
+    {
+      displayName: "TikTok Commercial Content Type",
+      name: "tiktokCommercialContentType",
+      type: "options",
+      options: [
+        { name: "None", value: "none" },
+        { name: "Your Brand (Organic)", value: "brand_organic" },
+        { name: "Branded Content (Partnership)", value: "brand_content" },
+      ],
+      default: "none",
+      displayOptions: {
+        show: {
+          resource: ["posts"],
+          operation: ["create", "update"],
+          selectedPlatforms: ["tiktok"],
+        },
+      },
+      description: "Commercial content disclosure required by TikTok when promoting a brand",
+    },
+    {
+      displayName: "TikTok Brand Partner Promote",
+      name: "tiktokBrandPartnerPromote",
+      type: "boolean",
+      default: false,
+      displayOptions: {
+        show: {
+          resource: ["posts"],
+          operation: ["create", "update"],
+          selectedPlatforms: ["tiktok"],
+          tiktokCommercialContentType: ["brand_content"],
+        },
+      },
+      description: "Toggle Branded Content disclosure (paid partnership)",
+    },
+    {
+      displayName: "TikTok Is Brand Organic",
+      name: "tiktokIsBrandOrganic",
+      type: "boolean",
+      default: false,
+      displayOptions: {
+        show: {
+          resource: ["posts"],
+          operation: ["create", "update"],
+          selectedPlatforms: ["tiktok"],
+          tiktokCommercialContentType: ["brand_organic"],
+        },
+      },
+      description: "Toggle Your Brand disclosure (promoting your own brand)",
+    },
+    {
+      displayName: "TikTok Video Made With AI",
+      name: "tiktokVideoMadeWithAi",
+      type: "boolean",
+      default: false,
+      displayOptions: {
+        show: {
+          resource: ["posts"],
+          operation: ["create", "update"],
+          selectedPlatforms: ["tiktok"],
+          tiktokMediaType: ["VIDEO"],
+        },
+      },
+      description: "Declare the video as AI-generated content (TikTok AIGC label)",
+    },
+    {
+      displayName: "TikTok Video Cover Timestamp (ms)",
+      name: "tiktokVideoCoverTimestampMs",
+      type: "number",
+      default: 1000,
+      typeOptions: { minValue: 0 },
+      displayOptions: {
+        show: {
+          resource: ["posts"],
+          operation: ["create", "update"],
+          selectedPlatforms: ["tiktok"],
+          tiktokMediaType: ["VIDEO"],
+        },
+      },
+      description: "Timestamp (ms) of the video frame to use as the cover image",
+    },
+
     // Unpublish fields
     {
       displayName: "Platform",

--- a/late/utils/routingHooks.ts
+++ b/late/utils/routingHooks.ts
@@ -108,7 +108,10 @@ function buildTagsArray(
 }
 
 /**
- * Builds TikTok settings if TikTok is selected
+ * Builds TikTok settings if TikTok is selected.
+ * Returns snake_case keys (the Zernio API normalizer maps them as-is).
+ * Optional fields are emitted only when the user set them, so the API's
+ * DEFAULT_TIKTOK_SETTINGS apply on the server side when omitted.
  */
 function buildTikTokSettings(executeFunctions: any, itemIndex: number): any {
   const selectedPlatforms = executeFunctions.getNodeParameter(
@@ -118,28 +121,56 @@ function buildTikTokSettings(executeFunctions: any, itemIndex: number): any {
   ) as string[];
   if (!selectedPlatforms.includes("tiktok")) return undefined;
 
-  return {
-    privacyLevel: executeFunctions.getNodeParameter(
-      "tiktokPrivacyLevel",
-      itemIndex,
-      "PUBLIC_TO_EVERYONE"
-    ),
-    allowComments: executeFunctions.getNodeParameter(
-      "tiktokAllowComments",
-      itemIndex,
-      true
-    ),
-    allowDuet: executeFunctions.getNodeParameter(
-      "tiktokAllowDuet",
-      itemIndex,
-      true
-    ),
-    allowStitch: executeFunctions.getNodeParameter(
-      "tiktokAllowStitch",
-      itemIndex,
-      true
-    ),
+  // Forward optional TikTok fields only when the user actually set them.
+  // The API normalizer applies DEFAULT_TIKTOK_SETTINGS server-side, so omitting
+  // a key here lets the platform default win (auto_add_music=false, etc.).
+  // Sending an explicit value would override that default unnecessarily.
+  const settings: Record<string, any> = {
+    privacy_level: executeFunctions.getNodeParameter("tiktokPrivacyLevel", itemIndex, "PUBLIC_TO_EVERYONE"),
+    allow_comment: executeFunctions.getNodeParameter("tiktokAllowComments", itemIndex, true),
+    allow_duet: executeFunctions.getNodeParameter("tiktokAllowDuet", itemIndex, true),
+    allow_stitch: executeFunctions.getNodeParameter("tiktokAllowStitch", itemIndex, true),
   };
+
+  const mediaType = executeFunctions.getNodeParameter("tiktokMediaType", itemIndex, "VIDEO") as string;
+
+  // Emit media_type only when user opted into PHOTO. Keeps existing
+  // VIDEO-only workflows byte-identical to pre-feature behavior.
+  if (mediaType === "PHOTO") {
+    settings.media_type = "PHOTO";
+
+    const description = executeFunctions.getNodeParameter("tiktokDescription", itemIndex, "") as string;
+    if (description) settings.description = description;
+
+    settings.auto_add_music = executeFunctions.getNodeParameter("tiktokAutoAddMusic", itemIndex, false);
+  } else {
+    // VIDEO branch: AIGC + cover timestamp are video-only per TikTok API.
+    const aigc = executeFunctions.getNodeParameter("tiktokVideoMadeWithAi", itemIndex, false);
+    if (aigc) settings.video_made_with_ai = true;
+
+    const coverMs = executeFunctions.getNodeParameter("tiktokVideoCoverTimestampMs", itemIndex, 1000);
+    // Default 1000ms matches libs/platforms/tiktok.ts fallback; omit when default
+    // so payload stays identical to pre-feature behavior.
+    if (typeof coverMs === "number" && coverMs !== 1000) {
+      settings.video_cover_timestamp_ms = coverMs;
+    }
+  }
+
+  // 'none' is the n8n UI default and means "no disclosure". The API treats absence
+  // as 'none' too, so we omit the key entirely to avoid sending redundant data
+  // and to keep the request payload aligned with the legacy (4-field) behavior.
+  const commercialType = executeFunctions.getNodeParameter("tiktokCommercialContentType", itemIndex, "none") as string;
+  if (commercialType !== "none") {
+    settings.commercial_content_type = commercialType;
+    if (commercialType === "brand_content") {
+      settings.brand_partner_promote = executeFunctions.getNodeParameter("tiktokBrandPartnerPromote", itemIndex, false);
+    }
+    if (commercialType === "brand_organic") {
+      settings.is_brand_organic_post = executeFunctions.getNodeParameter("tiktokIsBrandOrganic", itemIndex, false);
+    }
+  }
+
+  return settings;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-zernio",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "n8n community node for Zernio API - Schedule and manage social media posts across 13 platforms: Twitter/X, Instagram, Facebook, LinkedIn, TikTok, YouTube, Threads, Bluesky, Pinterest, Reddit, Telegram, Google Business, and Snapchat",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Adds 8 new n8n UI fields for TikTok posts so users can publish PHOTO carousels with background music and declare commercial content / AI-generated content per TikTok policy.

New fields (all gated by `selectedPlatforms: tiktok`):
- `tiktokMediaType` — VIDEO or PHOTO (default VIDEO; gates PHOTO-only and VIDEO-only fields)
- `tiktokDescription` — caption for PHOTO carousels
- `tiktokAutoAddMusic` — auto-attach TikTok-recommended background music (PHOTO only)
- `tiktokCommercialContentType` — none / brand_organic / brand_content disclosure
- `tiktokBrandPartnerPromote` — Branded Content toggle (when type=brand_content)
- `tiktokIsBrandOrganic` — Your Brand toggle (when type=brand_organic)
- `tiktokVideoMadeWithAi` — AIGC label (VIDEO only)
- `tiktokVideoCoverTimestampMs` — cover frame timestamp (VIDEO only; default 1000ms)

`buildTikTokSettings` was rewritten to emit snake_case keys and conditionally include only fields the user explicitly set. This lets the API's `DEFAULT_TIKTOK_SETTINGS` apply server-side when omitted.

## Backwards compatibility

No breaking changes for existing workflows:

1. **UI param names unchanged.** The 4 original fields (`tiktokPrivacyLevel`, `tiktokAllowComments`, `tiktokAllowDuet`, `tiktokAllowStitch`) keep the same names, types, and defaults. Saved workflows load unchanged.
2. **Payload key shape changed from camelCase to snake_case** for the body sent to the API. This is handled transparently by the API normalizer at `Schedule-Posts-API/libs/utils/tiktok-settings-normalizer.ts:24-45`, which aliases both `allowComments` (legacy plural camelCase) and `allow_comment` (new snake_case) to the same canonical key.
3. **New fields all default to non-emitting values** (`tiktokMediaType=VIDEO`, `tiktokAutoAddMusic=false`, `tiktokCommercialContentType=none`, etc.), so existing VIDEO-only workflows produce a payload with exactly the same 4 keys as today.

## Files

- `late/resources/posts.ts` — 8 new INodeProperties declarations (+138)
- `late/utils/routingHooks.ts` — `buildTikTokSettings` rewrite (+75/-26)
- `CHANGELOG.md` — 0.6.0 entry
- `package.json` — version bump 0.5.4 to 0.6.0 (minor, additive feature)
- `README.md` — TikTok section updated with PHOTO carousel example

## Test plan

No automated test infrastructure in this repo (`package.json` test script is the default echo). Manual verification:

- [ ] Load the node in a local n8n instance
- [ ] Create a TikTok post with `tiktokMediaType=PHOTO` and `tiktokAutoAddMusic=true`; capture the outgoing body and confirm `tiktokSettings.media_type === "PHOTO"` and `tiktokSettings.auto_add_music === true`
- [ ] Re-run an existing VIDEO-only workflow; confirm payload has exactly the 4 legacy keys and no `media_type` is emitted
- [ ] Try `tiktokCommercialContentType=brand_content` with `tiktokBrandPartnerPromote=true`; confirm both keys emitted; confirm `brand_organic` related keys are absent

## Customer report

https://app.crisp.chat/website/20dea5d6-a684-4c80-b097-2258b0b41421/inbox/session_3bcee628-4004-4bc1-bfeb-76fd48719533/