### PR TITLE
ci: enable npm provenance on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ permissions:
   pull-requests: write
   packages: write
   issues: write
+  id-token: write
 
 jobs:
   publish:
@@ -119,7 +120,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "Publishing n8n-nodes-zernio to NPM..."
-          npm publish --access public
+          npm publish --access public --provenance
 
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           echo "✅ Successfully published n8n-nodes-zernio@$PACKAGE_VERSION to NPM"
@@ -133,7 +134,7 @@ jobs:
           # Swap package name for backwards-compatible dual publish
           node -e "const p=require('./package.json'); p.name='n8n-nodes-late'; require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n')"
           echo "Publishing n8n-nodes-late@$PACKAGE_VERSION to NPM..."
-          npm publish --access public
+          npm publish --access public --provenance
           echo "✅ Successfully published n8n-nodes-late@$PACKAGE_VERSION to NPM"
           # Restore original package name
           node -e "const p=require('./package.json'); p.name='n8n-nodes-zernio'; require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n')"


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission so the publish workflow can mint a Sigstore OIDC token
- Pass `--provenance` to both `npm publish` calls (zernio + legacy late dual publish)

## Why
n8n's [verified community node guidelines](https://docs.n8n.io/integrations/creating-nodes/build/reference/verification-guidelines/) require packages to be published from a GitHub Action with an [npm provenance statement](https://docs.npmjs.com/generating-provenance-statements). This has been mandatory since 2026-05-01.

All other npm provenance prerequisites are already in place: `runs-on: ubuntu-latest`, npm 10 (via Node 20), `NODE_AUTH_TOKEN`, `registry-url` set to the public npm registry, `package.json.repository` matching the public GitHub repo URL.

## Test plan
- [ ] Cut a release after merge (auto-release.yml will fire on the next code push to master)
- [ ] Confirm the publish step logs `Signed provenance statement` and does not fail with `OIDC token unavailable`
- [ ] Verify the new version on https://www.npmjs.com/package/n8n-nodes-zernio shows a "Provenance" badge linking back to the GitHub Actions run
- [ ] Same check for https://www.npmjs.com/package/n8n-nodes-late

🤖 Generated with [Claude Code](https://claude.com/claude-code)