### PR TITLE
fix(posts): publish thread items + show Post ID for Unpublish (#28, #30)

### DIFF
--- a/late/utils/fieldBuilders.ts
+++ b/late/utils/fieldBuilders.ts
@@ -159,7 +159,7 @@ export function buildCommonPostFields(): INodeProperties[] {
       displayOptions: {
         show: {
           resource: ["posts"],
-          operation: ["get", "update", "delete", "retry", "logs"],
+          operation: ["get", "update", "delete", "retry", "unpublish", "logs"],
         },
       },
       description:

--- a/late/utils/routingHooks.ts
+++ b/late/utils/routingHooks.ts
@@ -176,6 +176,32 @@ function buildTikTokSettings(executeFunctions: any, itemIndex: number): any {
 /**
  * Pre-send hook for posts create operation
  */
+/**
+ * Attach thread/conversation items to the matching platform targets as
+ * platformSpecificData.threadItems, which is what the Late API actually reads.
+ * The thread items were previously sent as top-level twitterThread /
+ * threadsConversation / blueskyThread fields, which the API silently ignores, so
+ * threads never published (#28). Each n8n thread item carries { content, mediaItems
+ * (a nested fixedCollection) }, so unwrap mediaItems.items into a plain array.
+ */
+function attachThreadItems(
+  platforms: Array<{ platform: string; accountId: string; platformSpecificData?: any }>,
+  threadsByPlatform: Record<string, any[]>
+): void {
+  for (const entry of platforms) {
+    const rawItems = threadsByPlatform[entry.platform];
+    if (!rawItems || rawItems.length === 0) continue;
+    const threadItems = rawItems.map((it: any) => ({
+      content: it.content ?? "",
+      mediaItems: it.mediaItems?.items ?? [],
+    }));
+    entry.platformSpecificData = {
+      ...(entry.platformSpecificData ?? {}),
+      threadItems,
+    };
+  }
+}
+
 export async function postsCreatePreSend(
   this: any,
   requestOptions: any
@@ -205,6 +231,13 @@ export async function postsCreatePreSend(
     );
   }
 
+  // Threads publish via platforms[].platformSpecificData.threadItems, not top-level fields.
+  attachThreadItems(platforms, {
+    twitter: processedParams.twitterThreadItems?.items || [],
+    threads: processedParams.threadsThreadItems?.items || [],
+    bluesky: processedParams.blueskyThreadItems?.items || [],
+  });
+
   // Build the body with processed parameters
   requestOptions.body = {
     content: this.getNodeParameter("content", 0),
@@ -216,9 +249,6 @@ export async function postsCreatePreSend(
     visibility: this.getNodeParameter("visibility", 0, "public"),
     tags: buildTagsArray(this, 0),
     mediaItems: processedParams.mediaItems?.items || [],
-    twitterThread: processedParams.twitterThreadItems?.items || [],
-    threadsConversation: processedParams.threadsThreadItems?.items || [],
-    blueskyThread: processedParams.blueskyThreadItems?.items || [],
     tiktokSettings: buildTikTokSettings(this, 0),
   };
 
@@ -243,9 +273,16 @@ export async function postsUpdatePreSend(
     0
   );
 
+  const platforms = buildPlatformsArray(this, 0);
+  attachThreadItems(platforms, {
+    twitter: processedParams.twitterThreadItems?.items || [],
+    threads: processedParams.threadsThreadItems?.items || [],
+    bluesky: processedParams.blueskyThreadItems?.items || [],
+  });
+
   requestOptions.body = {
     content: this.getNodeParameter("content", 0),
-    platforms: buildPlatformsArray(this, 0),
+    platforms,
     scheduledFor: this.getNodeParameter("scheduledFor", 0),
     timezone: this.getNodeParameter("timezone", 0),
     publishNow: this.getNodeParameter("publishNow", 0),
@@ -253,9 +290,6 @@ export async function postsUpdatePreSend(
     visibility: this.getNodeParameter("visibility", 0),
     tags: buildTagsArray(this, 0, true), // Allow undefined for updates
     mediaItems: processedParams.mediaItems?.items || [],
-    twitterThread: processedParams.twitterThreadItems?.items || [],
-    threadsConversation: processedParams.threadsThreadItems?.items || [],
-    blueskyThread: processedParams.blueskyThreadItems?.items || [],
     tiktokSettings: buildTikTokSettings(this, 0),
   };
 


### PR DESCRIPTION
## Why
Two Posts-node bugs from the dashboard.

**#28 — threaded items never reached the API.** The node sent thread items as top-level `twitterThread`/`threadsConversation`/`blueskyThread` fields, but the Late API reads threads from `platforms[].platformSpecificData.threadItems` and ignores those keys, so only the first post published.

**#30 — Unpublish had no Post ID field.** The operation's URL uses `{{ $parameter.postId }}`, but the Post ID field's `displayOptions` omitted `unpublish`, so the field never rendered.

## What
- Map each platform's thread items into `platformSpecificData.threadItems` (unwrapping the nested `mediaItems` fixedCollection); drop the dead top-level fields. Create + Update.
- Add `unpublish` to the Post ID field's operation list.

All-platforms unpublish needs API support (endpoint requires one platform); #29 (dynamic media array) is a separate follow-up. `tsc` build passes.