### PR TITLE
feat(posts): accept a dynamic media array via Media Items (JSON) (#29)

### DIFF
--- a/late/resources/posts.ts
+++ b/late/resources/posts.ts
@@ -186,6 +186,26 @@ export const postsResource: LateResourceModule = {
     // Media items with proper variable handling
     buildMediaItemsField(),
 
+    // Alternative media input: a dynamic JSON array (e.g. fed from a previous node).
+    // The fixedCollection above can't accept a whole array via expression, so this
+    // field lets workflows pass `[{ url, type }]` directly. Takes precedence when set.
+    {
+      displayName: "Media Items (JSON)",
+      name: "mediaItemsJson",
+      type: "string",
+      default: "",
+      typeOptions: { rows: 2 },
+      displayOptions: {
+        show: {
+          resource: ["posts"],
+          operation: ["create", "update"],
+        },
+      },
+      description:
+        'Alternative to Media Items: a JSON array of media objects, e.g. [{"url":"https://...","type":"image"}]. Use an expression to pass a dynamic array from a previous node. Takes precedence over Media Items when set.',
+      placeholder: '={{ $json.mediaItems }}',
+    },
+
     // Twitter Thread Fields
     {
       displayName: "Twitter Thread Items",

--- a/late/utils/routingHooks.ts
+++ b/late/utils/routingHooks.ts
@@ -202,6 +202,29 @@ function attachThreadItems(
   }
 }
 
+/**
+ * Resolve media items, preferring the "Media Items (JSON)" field when set. The
+ * fixedCollection Media Items field can't accept a whole array via expression, so
+ * this lets workflows pass a dynamic [{ url, type }] array (e.g. from a prior node).
+ */
+function resolveMediaItems(ctx: any, fixedCollectionItems: any[]): any[] {
+  const json = ctx.getNodeParameter("mediaItemsJson", 0, "");
+  if (!json) return fixedCollectionItems;
+  let parsed: any;
+  try {
+    parsed = typeof json === "string" ? JSON.parse(json) : json;
+  } catch {
+    throw new NodeOperationError(
+      ctx.getNode(),
+      'Media Items (JSON) must be a valid JSON array, e.g. [{"url":"https://...","type":"image"}]'
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw new NodeOperationError(ctx.getNode(), "Media Items (JSON) must be a JSON array.");
+  }
+  return parsed;
+}
+
 export async function postsCreatePreSend(
   this: any,
   requestOptions: any
@@ -248,7 +271,7 @@ export async function postsCreatePreSend(
     isDraft,
     visibility: this.getNodeParameter("visibility", 0, "public"),
     tags: buildTagsArray(this, 0),
-    mediaItems: processedParams.mediaItems?.items || [],
+    mediaItems: resolveMediaItems(this, processedParams.mediaItems?.items || []),
     tiktokSettings: buildTikTokSettings(this, 0),
   };
 
@@ -289,7 +312,7 @@ export async function postsUpdatePreSend(
     isDraft: this.getNodeParameter("isDraft", 0),
     visibility: this.getNodeParameter("visibility", 0),
     tags: buildTagsArray(this, 0, true), // Allow undefined for updates
-    mediaItems: processedParams.mediaItems?.items || [],
+    mediaItems: resolveMediaItems(this, processedParams.mediaItems?.items || []),
     tiktokSettings: buildTikTokSettings(this, 0),
   };
 


### PR DESCRIPTION
## Why
Closes #29. The Media Items `fixedCollection` can't accept a whole array via expression, so workflows that build media in a previous node had no way to pass `[{ url, type }]` in.

## What
Add a "Media Items (JSON)" string field that takes a JSON array (or an expression resolving to one, e.g. `{{ $json.mediaItems }}`). When set, it's parsed and used as `mediaItems`, taking precedence over the fixedCollection. Create + Update, with a clear error on invalid JSON / non-array. `tsc` build passes.